### PR TITLE
feat: Support for kubernetes deployment

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "kube/postgres-operator"]
 	path = kube/postgres-operator
-	url = https://github.com/CrunchyData/postgres-operator-examples
+	url = git@github.com:OliverFlecke/postgres-operator

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "kube/postgres-operator"]
+	path = kube/postgres-operator
+	url = https://github.com/CrunchyData/postgres-operator-examples

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ tracing-subscriber = { version = "0.3.17", features = [
 unicode-segmentation = "1.10.1"
 url = "2.4.1"
 urlencoding = "2.1.3"
+utoipa = { version = "4.1.0", features = ["axum_extras"] }
 uuid = { version = "1.4.1", features = ["v4", "serde"] }
 validator = "0.16.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ opentelemetry-semantic-conventions = "0.12.0"
 opentelemetry-stdout = { version = "0.1.0", features = ["trace"] }
 opentelemetry_sdk = "0.20.0"
 rand = { version = "0.8.5", features = ["std_rng"] }
+redis = "^0.20"
 reqwest = { version = "0.11.20", default-features = false, features = [
   "json",
   "cookies",
@@ -58,7 +59,7 @@ tracing-subscriber = { version = "0.3.17", features = [
 unicode-segmentation = "1.10.1"
 url = "2.4.1"
 urlencoding = "2.1.3"
-utoipa = { version = "4.1.0", features = ["axum_extras"] }
+utoipa = { version = "4.1.0", features = ["axum_extras", "yaml", "chrono", "uuid"] }
 uuid = { version = "1.4.1", features = ["v4", "serde"] }
 validator = "0.16.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,12 @@ tracing-subscriber = { version = "0.3.17", features = [
 unicode-segmentation = "1.10.1"
 url = "2.4.1"
 urlencoding = "2.1.3"
-utoipa = { version = "4.1.0", features = ["axum_extras", "yaml", "chrono", "uuid"] }
+utoipa = { version = "4.1.0", features = [
+  "axum_extras",
+  "yaml",
+  "chrono",
+  "uuid",
+] }
 uuid = { version = "1.4.1", features = ["v4", "serde"] }
 validator = "0.16.1"
 
@@ -80,7 +85,7 @@ vergen = { version = "8.2.4", features = ["git", "gitoxide", "time", "build"] }
 
 [dev-dependencies]
 claims = "0.7.1"
-fake = "2.8.0"
+fake = { version = "2.8.0", features = ["derive"] }
 hyper = "0.14.27"
 linkify = "0.10.0"
 once_cell = "1.18.0"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Web service example - Based on zero2prod
+
+This repository contains a setup for a standalone web service ("microservice") written in Rust. It is based on [Zero to Production in Rust](https://www.zero2prod.com), but written in [axum](https://docs.rs/axum) and has since been expanded with other additions. These include:
+
+## Additions
+
+- Deployment to a [Kubernetes](https://kubernetes.io) cluster
+- OpenApi documentation

--- a/configuration/base.yaml
+++ b/configuration/base.yaml
@@ -1,7 +1,9 @@
 application:
   port: 8000
   hmac_secret: "long-and-very-secret-random-key-needed-to-verify-message-integrity"
-redis_uri: "redis://127.0.0.1:6379"
+redis:
+  host: "127.0.0.1"
+  port: 6379
 database:
   host: "127.0.0.1"
   port: 5432

--- a/configuration/local.yaml
+++ b/configuration/local.yaml
@@ -1,5 +1,6 @@
 application:
   host: 127.0.0.1
   base_url: "http://127.0.0.1"
+  enable_background_worker: false
 database:
   require_ssl: false

--- a/kube/README.md
+++ b/kube/README.md
@@ -10,6 +10,8 @@ The easiest way to get started locally is with [minikube](https://minikube.sigs.
 
 ### Deploy postgres
 
+**NOTE** the operator method should be prefered.
+
 Create storage for postgres and install through a helm chart.
 
 - `kubectl apply -f postgres-pv.yaml`
@@ -69,9 +71,31 @@ export DATABASE_URL="postgres://${PGUSER}:${PGPASSWORD}@localhost:5432/${PGDATAB
 psql -h localhost
 ```
 
+Remember to run the relevant migrations afterwards.
+
+Permissions can also be an issue. See [here](https://access.crunchydata.com/documentation/postgres-operator/latest/tutorials/basic-setup/user-management#adjusting-privileges).
+
 ### Deploy Redis
 
-TODO
+Deploying with [Bitnami's operator](https://github.com/bitnami/charts/tree/main/bitnami/redis).
+
+```sh
+helm install my-redis oci://registry-1.docker.io/bitnamicharts/redis
+```
+
+This should be all that is needed. It will create a master node and two replicas (can be customized).
+
+To get the password for redis:
+
+```sh
+kubectl -n zero2prod get secret my-redis -o jsonpath='{.data.redis-password}' | base64 --decode
+```
+
+To access it from the local machine, the service for the master can be exposed with:
+
+```sh
+kubectl -n zero2prod port-forward service/my-redis-master 6379:6379
+```
 
 ### Deploy service
 
@@ -88,7 +112,13 @@ minikube addons enable ingress
 minikube tunnel # this has to stay open during testing
 ```
 
-To access local images in `minikube` the `load` command in combination with a `imagePullPolicy: Never`.
+To access local images in `minikube`
+
+```sh
+eval $(minikube -p minikube docker-env)
+```
+
+Alternatively: the `load` command in combination with a `imagePullPolicy: Never`.
 
 ```sh
 minikube image load <image name>

--- a/kube/README.md
+++ b/kube/README.md
@@ -1,0 +1,63 @@
+# Kubernetes deployment
+
+This document contains information to deploy the service to a kubernetes cluster.
+It will allow you to deploy the service itself with a postgres and Redis cluster,
+along with telemetry.
+
+The easiest way to get started locally is with [minikube](https://minikube.sigs.k8s.io/docs/).
+
+## Steps
+
+### Deploy postgres
+
+Create storage for postgres and install through a helm chart.
+
+- `kubectl apply -f postgres-pv.yaml`
+- `kubectl apply -f postgres-pvc.yaml`
+- `helm install postgres bitnami/postgresql --set persistence.existingClaim postgresql-pv-claim --set volumePermissions.enabled=true`
+
+The postgres instance should now be running. It will have been created with the name `postgres-postresql` (could be better named).
+The password can be retreived with:
+
+```sh
+kubectl get secret postgres-postgresql -o jsonpath="{.data.postgres-password}" | base64 --decode
+```
+
+To expose the DB to your local machine, use a port forward:
+
+```sh
+kubectl port-forward service/postgres-postgresql 5432:5432
+```
+
+To create the database and apply migrations, use the `sqlx` cli:
+
+```sh
+export DATABASE_URL="postgres://postgres:$(kubectl get secret postgres-postgresql -o jsonpath="{.data.postgres-password}" | base64 --decode)@localhost:5432/newsletter"
+sqlx database create
+sqlx migrate run
+```
+
+### Deploy Redis
+
+TODO
+
+### Deploy service
+
+To deploy the service, apply all the config files for the api:
+
+```sh
+kubectl apply -f api-deployment.yaml -f api-service.yaml -f api-ingress.yaml
+```
+
+Note for minikube: By default the ingress in not enabled locally. If you want to access it from your local machine, this has to be enabled.
+
+```sh
+minikube addons enable ingress
+minikube tunnel # this has to stay open during testing
+```
+
+To access local images in `minikube` the `load` command in combination with a `imagePullPolicy: Never`.
+
+```sh
+minikube image load <image name>
+```

--- a/kube/api-deployment.yaml
+++ b/kube/api-deployment.yaml
@@ -16,7 +16,7 @@ spec:
         app: api
     spec:
       containers:
-        - image: ghcr.io/oliverflecke/zero2prod:v0.3.0
+        - image: ghcr.io/oliverflecke/zero2prod:v0.5.1
           imagePullPolicy: Never
           name: api
           resources:
@@ -24,14 +24,26 @@ spec:
               memory: 1Gi
               cpu: 1
           env:
+            - name: APP_APPLICATION__HOST
+              value: "127.0.0.1"
+            - name: APP_APPLICATION__BASE_URL
+              value: "http://127.0.0.1"
             - name: APP_DATABASE__HOST
               # value: postgres-postgresql.zero2prod.svc.cluster.local
               valueFrom: { secretKeyRef: { name: mail-pguser-mail, key: host } }
             - name: APP_DATABASE__NAME
               valueFrom: { secretKeyRef: { name: mail-pguser-mail, key: dbname } }
-            - name: APP_DATABASE__USER
+            - name: APP_DATABASE__USERNAME
               valueFrom: { secretKeyRef: { name: mail-pguser-mail, key: user } }
             - name: APP_DATABASE__PASSWORD
               valueFrom: { secretKeyRef: { name: mail-pguser-mail, key: password } }
             - name: APP_DATABASE__REQUIRE_SSL
-              value: "false"
+              value: "true"
+            - name: APP_REDIS__HOST
+              value: my-redis-master.zero2prod.svc.cluster.local
+            - name: APP_REDIS__PORT
+              value: "6379"
+            - name: APP_REDIS__CREDENTIALS__USERNAME
+              value: default
+            - name: APP_REDIS__CREDENTIALS__PASSWORD
+              valueFrom: { secretKeyRef: { name: my-redis, key: redis-password } }

--- a/kube/api-deployment.yaml
+++ b/kube/api-deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: api
+  name: api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+        - image: ghcr.io/oliverflecke/zero2prod:v0.2.0
+          imagePullPolicy: Never
+          name: api
+          resources:
+            limits:
+              memory: 1Gi
+              cpu: 1
+          env:
+            - name: APP_DATABASE__HOST
+              value: postgres-postgresql.zero2prod.svc.cluster.local
+            - name: APP_DATABASE__REQUIRE_SSL
+              value: "false"
+            - name: APP_DATABASE__PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-postgresql
+                  key: postgres-password

--- a/kube/api-deployment.yaml
+++ b/kube/api-deployment.yaml
@@ -16,7 +16,7 @@ spec:
         app: api
     spec:
       containers:
-        - image: ghcr.io/oliverflecke/zero2prod:v0.2.0
+        - image: ghcr.io/oliverflecke/zero2prod:v0.3.0
           imagePullPolicy: Never
           name: api
           resources:
@@ -25,11 +25,13 @@ spec:
               cpu: 1
           env:
             - name: APP_DATABASE__HOST
-              value: postgres-postgresql.zero2prod.svc.cluster.local
+              # value: postgres-postgresql.zero2prod.svc.cluster.local
+              valueFrom: { secretKeyRef: { name: mail-pguser-mail, key: host } }
+            - name: APP_DATABASE__NAME
+              valueFrom: { secretKeyRef: { name: mail-pguser-mail, key: dbname } }
+            - name: APP_DATABASE__USER
+              valueFrom: { secretKeyRef: { name: mail-pguser-mail, key: user } }
+            - name: APP_DATABASE__PASSWORD
+              valueFrom: { secretKeyRef: { name: mail-pguser-mail, key: password } }
             - name: APP_DATABASE__REQUIRE_SSL
               value: "false"
-            - name: APP_DATABASE__PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-postgresql
-                  key: postgres-password

--- a/kube/api-ingress.yaml
+++ b/kube/api-ingress.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: api-ingress
+spec:
+  defaultBackend:
+    service:
+      name: api-service
+      port:
+        number: 8000

--- a/kube/api-service.yaml
+++ b/kube/api-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-service
+spec:
+  type: NodePort
+  selector:
+    app: api
+  ports:
+    - port: 8000

--- a/kube/namespace.yaml
+++ b/kube/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: zero2prod
+  labels:
+    name: zero2prod

--- a/kube/postgres-pv.yaml
+++ b/kube/postgres-pv.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: postgresql-pv
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/mnt/data"

--- a/kube/postgres-pvc.yaml
+++ b/kube/postgres-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgresql-pv-claim
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/scripts/init_redis.sh
+++ b/scripts/init_redis.sh
@@ -3,7 +3,7 @@ set -x
 set -eo pipefail
 
 # If a redis container is running, print instructions to kill it and exit
-RUNNING_CONTAINER=$(docker ps --filter 'name=redis' --format '{{.ID}}')
+RUNNING_CONTAINER=$(docker ps --filter 'name=local_redis' --format '{{.ID}}')
 if [[ -n $RUNNING_CONTAINER ]]; then
   echo >&2 "there is a redis container already running, kill it with"
   echo >&2 "    docker kill ${RUNNING_CONTAINER}"
@@ -14,7 +14,7 @@ fi
 docker run \
   -p 6379:6379 \
   -d \
-  --name "redis_$(date '+%s')" \
+  --name "local_redis_$(date '+%s')" \
   redis:7-alpine
 
 >&2 echo "Redis is ready to go!"

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -83,6 +83,7 @@ pub struct ApplicationSettings {
     pub host: String,
     pub base_url: String,
     hmac_secret: Secret<String>,
+    enable_background_worker: bool,
 }
 
 impl ApplicationSettings {

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -185,3 +185,38 @@ impl EmailClientSettings {
         Duration::from_millis(self.timeout_milliseconds)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use fake::{Fake, Faker};
+    use pretty_assertions::assert_str_eq;
+
+    #[test]
+    fn redis_config_to_url() {
+        let config = RedisSettings {
+            host: Faker.fake(),
+            port: Faker.fake(),
+            credentials: Some(RedisCredentials {
+                username: Faker.fake(),
+                password: Secret::new(Faker.fake()),
+            }),
+        };
+
+        assert_str_eq!(
+            config.url().expose_secret().as_str(),
+            format!(
+                "redis://{}:{}@{}:{}",
+                config.credentials().as_ref().unwrap().username(),
+                config
+                    .credentials()
+                    .as_ref()
+                    .unwrap()
+                    .password()
+                    .expose_secret(),
+                config.host(),
+                config.port()
+            )
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,8 +99,8 @@ impl App {
             )
             .layer(Self::build_session_layer(config)?)
             // Routes after this layer does not have access to the user sessions.
-            .nest("/", health::create_router().with_state(app_state.clone()))
-            .nest("/", docs::create_router());
+            .nest("/docs", docs::create_router())
+            .nest("/", health::create_router().with_state(app_state.clone()));
 
         Ok(router.layer(
             ServiceBuilder::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ impl App {
             )
             .layer(Self::build_session_layer(config)?)
             // Routes after this layer does not have access to the user sessions.
-            .nest("/", health::create_router());
+            .nest("/", health::create_router().with_state(app_state.clone()));
 
         Ok(router.layer(
             ServiceBuilder::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,8 @@ pub mod telemetry;
 use crate::require_login::AuthorizedUser;
 use async_redis_session::RedisSessionStore;
 use axum::{
-    error_handling::HandleErrorLayer, middleware::from_extractor_with_state, BoxError, Router,
-    Server,
+    error_handling::HandleErrorLayer, middleware::from_extractor_with_state, routing::get,
+    BoxError, Router, Server,
 };
 use axum_sessions::SessionLayer;
 use configuration::Settings;
@@ -95,7 +95,8 @@ impl App {
             )
             .layer(Self::build_session_layer(config)?)
             // Routes after this layer does not have access to the user sessions.
-            .nest("/", health::create_router().with_state(app_state.clone()));
+            .nest("/", health::create_router().with_state(app_state.clone()))
+            .route("/openapi.json", get(serve_openapi_docs));
 
         Ok(router.layer(
             ServiceBuilder::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@ impl App {
     fn build_session_layer(config: &Settings) -> anyhow::Result<SessionLayer<RedisSessionStore>> {
         use secrecy::ExposeSecret;
 
-        let store = RedisSessionStore::new(config.redis_uri().expose_secret().as_str())?;
+        let store = RedisSessionStore::new(config.redis().url().expose_secret().as_str())?;
         let secret = config
             .application()
             .hmac_secret()

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ async fn main() -> anyhow::Result<()> {
     telemetry::init_subscriber(subscriber);
 
     let configuration = get_configuration().expect("Failed to read configuration.");
+    tracing::debug!("{:#?}", configuration);
 
     let application = App::build(configuration.clone()).await?;
     let application_task = tokio::spawn(application.run_until_stopped());

--- a/src/routes/docs.rs
+++ b/src/routes/docs.rs
@@ -47,3 +47,18 @@ pub async fn serve_openapi_docs_as_yaml() -> impl IntoResponse {
         ApiDoc::openapi().to_yaml().unwrap(),
     )
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn docs_can_be_converted_to_json_string() {
+        assert!(ApiDoc::openapi().to_json().is_ok());
+    }
+
+    #[test]
+    fn docs_can_be_converted_to_yaml_string() {
+        assert!(ApiDoc::openapi().to_yaml().is_ok());
+    }
+}

--- a/src/routes/docs.rs
+++ b/src/routes/docs.rs
@@ -1,0 +1,49 @@
+use crate::routes::*;
+use axum::{headers::ContentType, response::IntoResponse, routing::get, Router, TypedHeader};
+use http::{
+    header::{self, ACCEPT},
+    HeaderMap,
+};
+use utoipa::OpenApi;
+
+/// Documentation for the service. Can be converted into JSON or YAML.
+#[derive(OpenApi)]
+#[openapi(
+    paths(health::is_alive, health::status, health::build_info, home::home),
+    components(schemas(health::Status, health::BuildInfo))
+)]
+struct ApiDoc;
+
+pub fn create_router() -> Router {
+    Router::new()
+        .route("/openapi", get(serve_openapi_docs))
+        .route("/openapi.json", get(serve_openapi_docs_as_json))
+        .route("/openapi.yaml", get(serve_openapi_docs_as_yaml))
+}
+
+/// Serve OpenApi docs based on the `Accept` header.
+#[tracing::instrument(skip(headers))]
+pub async fn serve_openapi_docs(headers: HeaderMap) -> impl IntoResponse {
+    match headers.get(ACCEPT).and_then(|x| x.to_str().ok()) {
+        Some("application/yaml") => serve_openapi_docs_as_yaml().await.into_response(),
+        _ => serve_openapi_docs_as_json().await.into_response(),
+    }
+}
+
+/// Endpoint to serve OpenApi docs as JSON.
+#[tracing::instrument]
+pub async fn serve_openapi_docs_as_json() -> impl IntoResponse {
+    (
+        TypedHeader(ContentType::json()),
+        ApiDoc::openapi().to_json().unwrap(),
+    )
+}
+
+/// Endpoint to serve OpenApi docs as YAML.
+#[tracing::instrument]
+pub async fn serve_openapi_docs_as_yaml() -> impl IntoResponse {
+    (
+        [(header::CONTENT_TYPE, "application/yaml")],
+        ApiDoc::openapi().to_yaml().unwrap(),
+    )
+}

--- a/src/routes/health.rs
+++ b/src/routes/health.rs
@@ -55,7 +55,14 @@ async fn status(State(db_pool): State<Arc<PgPool>>) -> Json<Status> {
     // TODO: Can this be done once instead of everytime to report the
     // connection status? On the other hand, it should also report a up-to-date
     // response.
-    let db_connected = db_pool.acquire().await.is_ok();
+    let db_connected = db_pool
+        .acquire()
+        .await
+        .map_err(|e| {
+            tracing::error!("{:?}", e);
+            e
+        })
+        .is_ok();
 
     let status = Status { db_connected };
     tracing::info!("Status: {:?}", status);

--- a/src/routes/home/mod.rs
+++ b/src/routes/home/mod.rs
@@ -3,10 +3,19 @@ use askama::Template;
 use axum::{response::IntoResponse, routing::get, Router};
 
 pub fn create_router() -> Router<AppState> {
-    Router::new().route("/", get(home_handler))
+    Router::new().route("/", get(home))
 }
 
-async fn home_handler() -> impl IntoResponse {
+/// Serves the HTML for the home page.
+#[tracing::instrument]
+#[utoipa::path(
+    get,
+    path = "/",
+    responses(
+        (status = OK, description = "Home page for the service", content_type = "text/html")
+    )
+)]
+async fn home() -> impl IntoResponse {
     HomeTemplate.into_response()
 }
 

--- a/src/routes/login/post.rs
+++ b/src/routes/login/post.rs
@@ -61,6 +61,8 @@ pub async fn login(
 }
 
 fn login_redirect(flash_message: FlashMessage, e: LoginError) -> Response {
+    tracing::error!("{:?}", e);
+
     (
         flash_message.set_message(e.to_string()),
         Redirect::to("/login"),

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,24 +1,6 @@
-use axum::{headers::ContentType, response::IntoResponse, TypedHeader};
-use utoipa::OpenApi;
-
 pub mod admin;
+pub mod docs;
 pub mod health;
 pub mod home;
 pub mod login;
 pub mod subscriptions;
-
-#[derive(OpenApi)]
-#[openapi(
-    paths(health::is_alive, health::status, health::build_info),
-    components(schemas(health::Status, health::BuildInfo))
-)]
-struct ApiDoc;
-
-/// Endpoint to server openapi docs.
-pub async fn serve_openapi_docs() -> impl IntoResponse {
-    (
-        TypedHeader(ContentType::json()),
-        ApiDoc::openapi().to_json().unwrap(),
-    )
-        .into_response()
-}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,31 +1,5 @@
-use crate::{require_login::AuthorizedUser, state::AppState};
-use axum::{middleware::from_extractor_with_state, Router};
-
 pub mod admin;
 pub mod health;
 pub mod home;
 pub mod login;
 pub mod subscriptions;
-
-pub fn build_router(app_state: &AppState) -> Router {
-    Router::new()
-        .nest("/", health::create_router())
-        .nest("/", home::create_router().with_state(app_state.clone()))
-        .nest(
-            "/login",
-            login::create_router().with_state(app_state.clone()),
-        )
-        .nest(
-            "/admin",
-            admin::create_router()
-                // Enforce authorized user on all admin endpoints.
-                .route_layer(from_extractor_with_state::<AuthorizedUser, AppState>(
-                    app_state.clone(),
-                ))
-                .with_state(app_state.clone()),
-        )
-        .nest(
-            "/subscriptions",
-            subscriptions::create_router().with_state(app_state.clone()),
-        )
-}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,5 +1,24 @@
+use axum::{headers::ContentType, response::IntoResponse, TypedHeader};
+use utoipa::OpenApi;
+
 pub mod admin;
 pub mod health;
 pub mod home;
 pub mod login;
 pub mod subscriptions;
+
+#[derive(OpenApi)]
+#[openapi(
+    paths(health::is_alive, health::status, health::build_info),
+    components(schemas(health::Status, health::BuildInfo))
+)]
+struct ApiDoc;
+
+/// Endpoint to server openapi docs.
+pub async fn serve_openapi_docs() -> impl IntoResponse {
+    (
+        TypedHeader(ContentType::json()),
+        ApiDoc::openapi().to_json().unwrap(),
+    )
+        .into_response()
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -12,6 +12,7 @@ pub mod session;
 #[derive(Clone, Getters)]
 pub struct AppState {
     db_pool: Arc<PgPool>,
+    redis_client: Arc<redis::Client>,
     email_client: Arc<EmailClient>,
     application_base_url: Arc<ApplicationBaseUrl>,
     hmac_secret: Arc<HmacSecret>,
@@ -19,9 +20,16 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub async fn create(config: &Settings, db_pool: PgPool, email_client: EmailClient) -> Self {
+    /// Create a new container for all of the app state.
+    pub async fn create(
+        config: &Settings,
+        db_pool: PgPool,
+        email_client: EmailClient,
+        redis_client: redis::Client,
+    ) -> Self {
         Self {
             db_pool: Arc::new(db_pool),
+            redis_client: Arc::new(redis_client),
             email_client: Arc::new(email_client),
             application_base_url: Arc::new(ApplicationBaseUrl(
                 config.application().base_url().clone(),
@@ -38,6 +46,7 @@ impl AppState {
     [ EmailClient ]         [ email_client ];
     [ ApplicationBaseUrl ]  [ application_base_url ];
     [ HmacSecret ]          [ hmac_secret ];
+    [ redis::Client ]       [ redis_client ];
 )]
 impl FromRef<AppState> for Arc<service_type> {
     fn from_ref(app_state: &AppState) -> Self {

--- a/tests/api/docs.rs
+++ b/tests/api/docs.rs
@@ -1,0 +1,86 @@
+use http::{
+    header::{ACCEPT, CONTENT_TYPE},
+    StatusCode,
+};
+use rstest::rstest;
+
+use crate::utils::spawn_app;
+
+#[tokio::test]
+async fn open_api_documentation_can_be_retrieved_as_json() {
+    // Arrange
+    let app = spawn_app().await;
+
+    // Act
+    let response = app
+        .api_client()
+        .get(app.at_url("/docs/openapi.json"))
+        .send()
+        .await
+        .expect("Request failed");
+
+    // Assert
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_ne!(response.content_length(), Some(0));
+    assert_eq!(
+        response
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|x| x.to_str().ok()),
+        Some("application/json")
+    );
+}
+
+#[tokio::test]
+async fn open_api_documentation_can_be_retrieved_as_yaml() {
+    // Arrange
+    let app = spawn_app().await;
+
+    // Act
+    let response = app
+        .api_client()
+        .get(app.at_url("/docs/openapi.yaml"))
+        .send()
+        .await
+        .expect("Request failed");
+
+    // Assert
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_ne!(response.content_length(), Some(0));
+    assert_eq!(
+        response
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|x| x.to_str().ok()),
+        Some("application/yaml")
+    );
+}
+
+#[rstest]
+#[case("json")]
+#[case("yaml")]
+#[tokio::test]
+async fn open_api_documentation_can_be_retrieved(#[case] content_type: String) {
+    // Arrange
+    let app = spawn_app().await;
+
+    // Act
+    let response = app
+        .api_client()
+        .get(app.at_url("/docs/openapi"))
+        .header(ACCEPT, format!("application/{content_type}"))
+        .send()
+        .await
+        .expect("Request failed");
+
+    // Assert
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_ne!(response.content_length(), Some(0));
+    assert_eq!(
+        response
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|x| x.to_str().ok()),
+        Some(format!("application/{content_type}").as_str())
+    );
+}

--- a/tests/api/health.rs
+++ b/tests/api/health.rs
@@ -51,3 +51,35 @@ async fn info_endpoint_gives_build_info() {
         .and_then(|x| NaiveDateTime::parse_from_str(x, "%Y-%m-%dT%H:%M:%S%.f").ok())
         .is_some());
 }
+
+#[tokio::test]
+async fn status_endpoint_returns_up_when_both_services_are_up() {
+    // Arrange
+    let app = spawn_app().await;
+
+    // Act
+    let response = app
+        .api_client()
+        .get(app.at_url("/status"))
+        .send()
+        .await
+        .expect("Request failed");
+
+    // Assert
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.text().await.expect("unable to read body");
+    let body: Value = serde_json::from_str(&body).expect("unable to parse json");
+    assert_eq!(
+        body.get("is_db_connected")
+            .and_then(|x| x.as_bool())
+            .unwrap(),
+        true
+    );
+    assert_eq!(
+        body.get("is_redis_connected")
+            .and_then(|x| x.as_bool())
+            .unwrap(),
+        true
+    );
+}

--- a/tests/api/health.rs
+++ b/tests/api/health.rs
@@ -1,5 +1,8 @@
 use crate::utils::spawn_app;
 use axum::http::StatusCode;
+use chrono::NaiveDateTime;
+use pretty_assertions::assert_eq;
+use serde_json::Value;
 
 #[tokio::test]
 async fn health_check_works() {
@@ -12,4 +15,39 @@ async fn health_check_works() {
     // Assert
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(Some(0), response.content_length());
+}
+
+#[tokio::test]
+async fn info_endpoint_gives_build_info() {
+    // Arrange
+    let app = spawn_app().await;
+
+    // Act
+    let response = app
+        .api_client()
+        .get(app.at_url("/info"))
+        .send()
+        .await
+        .expect("Request failed");
+
+    // Assert
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.text().await.expect("unable to read body");
+    let body: Value = serde_json::from_str(&body).expect("unable to parse json");
+    assert!(body
+        .get("version")
+        .and_then(|x| x.as_str())
+        .filter(|x| !x.is_empty())
+        .is_some());
+    assert!(body
+        .get("build")
+        .and_then(|x| x.as_str())
+        .filter(|x| !x.is_empty())
+        .is_some());
+    assert!(body
+        .get("build_timestamp")
+        .and_then(|x| x.as_str())
+        .and_then(|x| NaiveDateTime::parse_from_str(x, "%Y-%m-%dT%H:%M:%S%.f").ok())
+        .is_some());
 }

--- a/tests/api/main.rs
+++ b/tests/api/main.rs
@@ -1,5 +1,6 @@
 mod admin_dashboard;
 mod change_password;
+mod docs;
 mod health;
 mod login;
 mod newsletter;


### PR DESCRIPTION
Adds support for deploying the service to kubernetes with a postgres database and redis instance.
Also started on adding OpenApi docs to the service.

## Changelog 

- docs: Kubernetes configuration
- fix: Health endpoint should not require session
- feat: Deployment with postgres operator
- feat: `status` endpoint to show db connection status
- feat: Introduced OpenAPI docs
- feat: Redis deployment in kubernetes
- fix: Logging config and missing errors
- docs: README for the project
- feat: Status endpoint to check redis connection and more OpenApi docs
- chore: Point submodule to owned repo
